### PR TITLE
Rename options sandbox to context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased][unreleased]
 
-## [2.x][] - 2020-12-17
+- Change signature `await new Config(dirPath, { sandbox })` to
+  `new Config(dirPath, { context })` for naming consistency with `metavm`
+
+## [2.0.0][] - 2020-12-17
 
 - Use `metavm` instead of `vm`
 - Return promise with sections from constructor
@@ -23,7 +26,7 @@
 - Support mode (log files second ext): `options.mode`
 - Support passing custom sandbox: `options.sandbox`
 
-[unreleased]: https://github.com/metarhia/config/compare/v2.x...HEAD
-[2.x]: https://github.com/metarhia/config/compare/v1.x...v2.x
+[unreleased]: https://github.com/metarhia/config/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/metarhia/config/compare/v1.x...v2.0.0
 [1.x]: https://github.com/metarhia/config/compare/v0.x...v1.x
 [0.x]: https://github.com/metarhia/config/releases/tag/v0.x

--- a/config.js
+++ b/config.js
@@ -6,12 +6,12 @@ const fsp = require('fs').promises;
 
 class Config {
   constructor(dirPath, options = {}) {
-    const { names, mode, sandbox } = options;
+    const { names, mode, context, sandbox } = options;
     this.sections = {};
     this.path = dirPath;
     this.names = names || null;
     this.mode = mode || '';
-    this.sandbox = sandbox || metavm.createContext();
+    this.context = context || sandbox || metavm.createContext();
     return this.load();
   }
 
@@ -38,7 +38,7 @@ class Config {
   async loadFile(file) {
     const configFile = path.join(this.path, file);
     const sectionName = file.substring(0, file.indexOf('.'));
-    const options = { context: this.sandbox };
+    const options = { context: this.context };
     const { exports } = await metavm.readScript(configFile, options);
     this.sections[sectionName] = exports;
   }

--- a/examples/example5/README.md
+++ b/examples/example5/README.md
@@ -1,0 +1,3 @@
+# Example 4
+
+This files should be omitted

--- a/examples/example5/application.js
+++ b/examples/example5/application.js
@@ -1,0 +1,4 @@
+({
+  name: 'Application name',
+  user: process.env.USER,
+});

--- a/test/test.js
+++ b/test/test.js
@@ -34,16 +34,16 @@ metatests.test('Server with logger', async (test) => {
       toStdout: ['system', 'fatal', 'error'],
     },
   };
-  const sandbox = { Duration: common.duration };
-  vm.createContext(sandbox);
-  const options = { sandbox };
+  const context = { Duration: common.duration };
+  vm.createContext(context);
+  const options = { context };
   const config = await new Config('./examples/example2', options);
   test.strictSame(config, sections);
   test.end();
 });
 
 metatests.test('Application server', async (test) => {
-  const sandbox = { Duration: common.duration };
+  const context = { Duration: common.duration };
   const sections = {
     application: { name: 'Application name' },
     gateway: { host: '10.0.0.1', port: 2000 },
@@ -54,8 +54,8 @@ metatests.test('Application server', async (test) => {
     server: { transport: 'http', address: '127.0.0.1', ports: 8080 },
     timeouts: { cache: 30000, relpy: 5000, query: 3000 },
   };
-  vm.createContext(sandbox);
-  const options = { sandbox, mode: 'test' };
+  vm.createContext(context);
+  const options = { context, mode: 'test' };
   const config = await new Config('./examples/example3', options);
   test.strictSame(config, sections);
   test.end();

--- a/test/test.js
+++ b/test/test.js
@@ -92,3 +92,18 @@ metatests.test('Specified sections with options', async (test) => {
   test.strictSame(config, sections);
   test.end();
 });
+
+metatests.test('Compatibility with old signature', async (test) => {
+  const context = { process };
+  const sections = {
+    application: {
+      name: 'Application name',
+      user: process.env.USER,
+    },
+  };
+  vm.createContext(context);
+  const options = { context, mode: 'test' };
+  const config = await new Config('./examples/example5', options);
+  test.strictSame(config, sections);
+  test.end();
+});


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] tests are added/updated for bug fixes and new features
- [x] code is properly formatted (`npm run fmt`)
