### PR TITLE
Remove `names` argument from configuration factory function

### DIFF
--- a/config.js
+++ b/config.js
@@ -44,7 +44,6 @@ class Config {
   }
 }
 
-const readConfig = (dirPath, options, names) =>
-  new Config(dirPath, options, names);
+const readConfig = (dirPath, options) => new Config(dirPath, options);
 
 module.exports = { Config, readConfig };


### PR DESCRIPTION
<!--
Thank you for your pull request.
Check following steps to help us land your changes:
Change [ ] to [x] for completed items.
-->

Remove `names` argument from `readConfig` function because it doesn't do anything due to the removal of that argument in `Configuration` class constructor.

```javascript
const readConfig = (dirPath, options, names) =>
  new Config(dirPath, options, names);
```

```javascript
class Config {
  constructor(dirPath, options = {}) {
    ...
  }
}
```

- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
