### PR TITLE
Eslint: change arrow-parens to always

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,10 @@
 {
   "extends": ["metarhia", "plugin:prettier/recommended"],
-  "parserOptions": { "ecmaVersion": 2020 }
+  "parserOptions": { "ecmaVersion": 2020 },
+  "rules": {
+    "arrow-parens": ["error", "always"],
+    "comma-dangle": "off",
+    "handle-callback-err": "off",
+    "consistent-return": "off"
+  }
 }


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)
